### PR TITLE
XSRF token fix

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -17,38 +17,38 @@ def main():
 
     subparsers = parser.add_subparsers(help='sub-command help')
 
-    postParser = subparsers.add_parser('post', help='post a new ad')
-    postParser.add_argument('inf_file', type=str, help='.inf file containing posting details')
-    postParser.set_defaults(function=post_ad)
+    post_parser = subparsers.add_parser('post', help='post a new ad')
+    post_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    post_parser.set_defaults(function=post_ad)
 
-    folderParser = subparsers.add_parser('folder', help='post ad from folder')
-    folderParser.add_argument('folderName', type=str, help='folder containing ad details')
-    folderParser.set_defaults(function=post_folder)
+    folder_parser = subparsers.add_parser('folder', help='post ad from folder')
+    folder_parser.add_argument('folder_name', type=str, help='folder containing ad details')
+    folder_parser.set_defaults(function=post_folder)
 
-    repostFolderParser = subparsers.add_parser('repost_folder', help='post ad from folder')
-    repostFolderParser.add_argument('folderName', type=str, help='folder containing ad details')
-    repostFolderParser.set_defaults(function=repost_folder)
+    repost_folder_parser = subparsers.add_parser('repost_folder', help='post ad from folder')
+    repost_folder_parser.add_argument('folder_name', type=str, help='folder containing ad details')
+    repost_folder_parser.set_defaults(function=repost_folder)
 
-    showParser = subparsers.add_parser('show', help='show currently listed ads')
-    showParser.set_defaults(function=show_ads)
+    show_parser = subparsers.add_parser('show', help='show currently listed ads')
+    show_parser.set_defaults(function=show_ads)
 
-    deleteParser = subparsers.add_parser('delete', help='delete a listed ad')
-    deleteParser.add_argument('id', type=str, help='id of the ad you wish to delete')
-    deleteParser.set_defaults(function=delete_ad)
+    delete_parser = subparsers.add_parser('delete', help='delete a listed ad')
+    delete_parser.add_argument('id', type=str, help='id of the ad you wish to delete')
+    delete_parser.set_defaults(function=delete_ad)
 
-    nukeParser = subparsers.add_parser('nuke', help='delete all ads')
-    nukeParser.set_defaults(function=nuke)
+    nuke_parser = subparsers.add_parser('nuke', help='delete all ads')
+    nuke_parser.set_defaults(function=nuke)
 
-    checkParser = subparsers.add_parser('check_ad', help='check if ad is active')
-    checkParser.add_argument('folderName', type=str, help='folder containing ad details')
-    checkParser.set_defaults(function=check_ad)
+    check_parser = subparsers.add_parser('check_ad', help='check if ad is active')
+    check_parser.add_argument('folder_name', type=str, help='folder containing ad details')
+    check_parser.set_defaults(function=check_ad)
 
-    repostParser = subparsers.add_parser('repost', help='repost an existing ad')
-    repostParser.add_argument('inf_file', type=str, help='.inf file containing posting details')
-    repostParser.set_defaults(function=repost_ad)
+    repost_parser = subparsers.add_parser('repost', help='repost an existing ad')
+    repost_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    repost_parser.set_defaults(function=repost_ad)
 
-    buildParser = subparsers.add_parser('build_ad', help='Generates the item.inf file for a new ad')
-    buildParser.set_defaults(function=generate_inf_file)
+    build_parser = subparsers.add_parser('build_ad', help='Generates the item.inf file for a new ad')
+    build_parser.set_defaults(function=generate_inf_file)
 
     args = parser.parse_args()
     try:
@@ -62,7 +62,7 @@ def get_folder_data(args):
     Set ad data inf file and extract login credentials from inf files
     """
     args.inf_file = "item.inf"
-    cred_file = args.folderName + "/login.inf"
+    cred_file = args.folder_name + "/login.inf"
     creds = [line.strip() for line in open(cred_file, 'r')]
     args.username = creds[0]
     args.password = creds[1]
@@ -83,7 +83,7 @@ def post_folder(args):
     Post new ad from folder
     """
     get_folder_data(args)
-    os.chdir(args.folderName)
+    os.chdir(args.folder_name)
     post_ad(args)
 
 
@@ -91,18 +91,18 @@ def post_ad(args):
     """
     Post new ad
     """
-    [data, imageFiles] = get_inf_details(args.inf_file)
+    [data, image_files] = get_inf_details(args.inf_file)
     attempts = 1
     while not check_ad(args) and attempts < 5:
         if attempts > 1:
-            print("Failed Attempt #" + str(attempts) + ", trying again.")
+            print("Failed Attempt #{}, trying again.".format(attempts))
         attempts += 1
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
-        api.post_ad_using_data(data, imageFiles)
+        api.post_ad_using_data(data, image_files)
         sleep(180)
     if not check_ad(args):
-        print("Failed Attempt #" + str(attempts) + ", giving up.")
+        print("Failed Attempt #{}, giving up.".format(attempts))
 
 
 def show_ads(args):
@@ -111,7 +111,7 @@ def show_ads(args):
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    [print("{} '{}'".format(adId, adName)) for adName, adId in api.get_all_ads()]
+    [print("{} '{}'".format(ad_id, ad_name)) for ad_name, ad_id in api.get_all_ads()]
 
 
 def delete_ad(args):
@@ -139,13 +139,13 @@ def repost_ad(args):
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    delAdName = ""
+    del_ad_name = ""
     for line in open(args.inf_file, 'rt'):
         [key, val] = line.strip().rstrip("\n").split("=")
         if key == "postAdForm.title":
-            delAdName = val
+            del_ad_name = val
     try:
-        api.delete_ad_using_title(delAdName)
+        api.delete_ad_using_title(del_ad_name)
         print("Existing ad deleted before reposting")
     except kijiji_api.DeleteAdException:
         print("Did not find an existing ad with matching title, skipping ad deletion")
@@ -160,7 +160,7 @@ def repost_folder(args):
     Repost ad from folder
     """
     get_folder_data(args)
-    os.chdir(args.folderName)
+    os.chdir(args.folder_name)
     repost_ad(args)
 
 
@@ -170,13 +170,13 @@ def check_ad(args):
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    AdName = ""
+    ad_name = ""
     for line in open(args.inf_file, 'rt'):
         [key, val] = line.strip().rstrip("\n").split("=")
         if key == "postAdForm.title":
-            AdName = val
-    allAds = api.get_all_ads()
-    return [t for t, i in allAds if t == AdName]
+            ad_name = val
+    all_ads = api.get_all_ads()
+    return [t for t, i in all_ads if t == ad_name]
 
 
 def nuke(args):
@@ -185,11 +185,13 @@ def nuke(args):
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    allAds = api.get_all_ads()
-    [api.delete_ad(adId) for adName, adId in allAds]
+    all_ads = api.get_all_ads()
+    [api.delete_ad(ad_id) for ad_name, ad_id in all_ads]
 
-def generate_inf_file(args):
+
+def generate_inf_file():
     generator.run_program()
+
 
 if __name__ == "__main__":
     main()

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -100,7 +100,6 @@ def post_ad(args):
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
         api.post_ad_using_data(data, image_files)
-        sleep(180)
     if not check_ad(args):
         print("Failed Attempt #{}, giving up.".format(attempts))
 

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -161,9 +161,9 @@ class KijijiApi:
             else:
                 raise KijijiApiException("Could not post ad.", resp.text)
 
-        # Get adId and return it
-        new_cookie_with_ad_id = resp.headers['Set-Cookie']
-        ad_id = re.search('\d+', new_cookie_with_ad_id).group()
+        # Extract ad ID from response set-cookie
+        ad_id = re.search('kjrva=(\d+)', resp.headers['Set-Cookie']).group(1)
+
         return ad_id
 
     def get_all_ads(self):

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -1,10 +1,10 @@
-import requests
 import json
-import bs4
 import re
 import sys
-from multiprocessing import Pool
 from time import strftime
+
+import bs4
+import requests
 
 if sys.version_info < (3, 0):
     raise Exception("This program requires Python 3.0 or greater")
@@ -20,23 +20,28 @@ class KijijiApiException(Exception):
             self.dumpfilepath = "kijiji_dump_{}.txt".format(strftime("%Y%m%dT%H%M%S"))
             with open(self.dumpfilepath, 'a') as f:
                 f.write(dump)
+
     def __str__(self):
         if self.dumpfilepath:
             return "See {} in current directory for latest dumpfile.".format(self.dumpfilepath)
         else:
             return ""
 
+
 class SignInException(KijijiApiException):
     def __str__(self):
         return "Could not sign in.\n"+super().__str__()
+
 
 class PostAdException(KijijiApiException):
     def __str__(self):
         return "Could not post ad.\n"+super().__str__()
 
+
 class BannedException(KijijiApiException):
     def __str__(self):
         return "Could not post ad, this user is banned.\n"+super().__str__()
+
 
 class DeleteAdException(KijijiApiException):
     def __str__(self):
@@ -45,8 +50,8 @@ class DeleteAdException(KijijiApiException):
 
 def get_token(html, token_name):
     """
-    Retrive CSRF token from webpage
-    Tokens are different every time a page is visitied
+    Retrieve CSRF token from webpage
+    Tokens are different every time a page is visited
     """
     soup = bs4.BeautifulSoup(html, 'html.parser')
     res = soup.select("[name={}]".format(token_name))
@@ -77,7 +82,7 @@ class KijijiApi:
             '_rememberMe': 'on',
             'ca.kijiji.xsrf.token': get_token(resp.text, 'ca.kijiji.xsrf.token'),
             'targetUrl': 'L3QtbG9naW4uaHRtbD90YXJnZXRVcmw9TDNRdGJHOW5hVzR1YUhSdGJEOTBZWEpuWlhSVmNtdzlUREpuZEZwWFVuUmlNalV3WWpJMGRGbFlTbXhaVXpoNFRucEJkMDFxUVhsWWJVMTZZbFZLU1dGVmJHdGtiVTVzVlcxa1VWSkZPV0ZVUmtWNlUyMWpPVkJSTFMxZVRITTBVMk5wVW5wbVRHRlFRVUZwTDNKSGNtVk9kejA5XnpvMnFzNmc2NWZlOWF1T1BKMmRybEE9PQ--'
-            }
+        }
         resp = self.session.post(login_url, data=payload)
         if not self.is_logged_in():
             raise SignInException(resp.text)
@@ -86,8 +91,7 @@ class KijijiApi:
         """
         Return true if logged into Kijiji for the current session
         """
-        index_page_text = self.session.get('https://www.kijiji.ca/m-my-ads.html/').text
-        return "Sign Out" in index_page_text
+        return "Sign Out" in self.session.get('https://www.kijiji.ca/m-my-ads.html/').text
 
     def logout(self):
         """
@@ -106,21 +110,21 @@ class KijijiApi:
             'needsRedirect': 'false',
             'ads': '[{{"adId":"{}","reason":"PREFER_NOT_TO_SAY","otherReason":""}}]'.format(ad_id),
             'ca.kijiji.xsrf.token': get_token(my_ads_page.text, 'ca.kijiji.xsrf.token')
-            }
+        }
         resp = self.session.post('https://www.kijiji.ca/j-delete-ad.json', data=params)
-        if ("OK" not in resp.text):
+        if "OK" not in resp.text:
             raise DeleteAdException(resp.text)
 
     def delete_ad_using_title(self, title):
         """
         Delete ad based on ad title
         """
-        allAds = self.get_all_ads()
-        [self.delete_ad(i) for t, i in allAds if t.strip() == title.strip()]
+        all_ads = self.get_all_ads()
+        [self.delete_ad(i) for t, i in all_ads if t.strip() == title.strip()]
 
     def upload_image(self, token, image_files=[]):
         """
-        Upload one or more photos to Kijiji concurrently using Pool
+        Upload one or more photos to Kijiji
 
         'image_files' is a list of binary objects corresponding to images
         """
@@ -130,7 +134,7 @@ class KijijiApi:
             for i in range(0, 3):
                 files = {'file': img_file}
                 r = self.session.post(image_upload_url, files=files, headers={"x-ebay-box-token": token})
-                if (r.status_code != 200):
+                if r.status_code != 200:
                     print(r.status_code)
                 try:
                     image_tree = json.loads(r.text)
@@ -138,7 +142,7 @@ class KijijiApi:
                     print("Image Upload success on try #{}".format(i+1))
                     image_urls.append(img_url)
                     break
-                except (KeyError, ValueError) as e:
+                except (KeyError, ValueError):
                     print("Image Upload failed on try #{}".format(i+1))
         return [image for image in image_urls if image is not None]
 
@@ -152,15 +156,15 @@ class KijijiApi:
         # Load ad posting page
         resp = self.session.get('https://www.kijiji.ca/p-admarkt-post-ad.html?categoryId=773')
 
-        #Get tokens required for upload
+        # Get tokens required for upload
         token_regex = r"initialXsrfToken: '\S+'"
         image_upload_token = re.findall(token_regex, resp.text)[0].strip("initialXsrfToken: '").strip("'")
 
         # Upload the images
-        imageList = self.upload_image(image_upload_token, image_files)
-        data['images'] = ",".join(imageList)
+        image_list = self.upload_image(image_upload_token, image_files)
+        data['images'] = ",".join(image_list)
 
-        # Retrive tokens for website
+        # Retrieve tokens for website
         data['ca.kijiji.xsrf.token'] = get_token(resp.text, 'ca.kijiji.xsrf.token')
         data['postAdForm.fraudToken'] = get_token(resp.text, 'postAdForm.fraudToken')
         data['postAdForm.description'] = data['postAdForm.description'].replace("\\n", "\n")
@@ -170,7 +174,7 @@ class KijijiApi:
         resp = self.session.post(new_ad_url, data=data)
         if not len(data.get("postAdForm.title", "")) >= 10:
             raise AssertionError("Your title is too short!")
-        if (int(resp.status_code) != 200 or \
+        if (int(resp.status_code) != 200 or
                 "Delete Ad?" not in resp.text):
             if "There was an issue posting your ad, please contact Customer Service." in resp.text:
                 raise BannedException(resp.text)
@@ -187,7 +191,7 @@ class KijijiApi:
         Return an iterator of tuples containing the ad title and ad ID for every ad
         """
         resp = self.session.get('https://www.kijiji.ca/m-my-ads.html')
-        user_id=get_token(resp.text, 'userId')
+        user_id = get_token(resp.text, 'userId')
         my_ads_url = 'https://www.kijiji.ca/j-get-my-ads.json?_=1&currentOffset=0&isPromoting=false&show=ACTIVE&user={}'.format(user_id)
         my_ads_page = self.session.get(my_ads_url)
         my_ads_tree = json.loads(my_ads_page.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests
 bs4
+requests
+pyyaml


### PR DESCRIPTION
Fix for recent changes in Kijiji's site on how it uses XSRF tokens

* Getting the XSRF token from the 'm-my-ads.html' page is a bit more involved now; you need to look elsewhere in the page to get it since it isn't in an HTML form input element anymore
* Also found out a nicer way to get the 'targetUrl' and 'userId' values using a JSON object within script tags (newly added from the recent site changes?)
* Cleaned up the KijijiApi exception classes and condensed all sub-classes into one exception class
* Removed the unnecessary sleep in _post_ad()_ immediately after (re)posting a new ad
* General cleanup of syntax and fixing typos