### PR TITLE
Common "login.inf" credentials file

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -51,6 +51,14 @@ def main():
     build_parser.set_defaults(function=generate_inf_file)
 
     args = parser.parse_args()
+
+    # Recursively look for the first "login.inf" credentials file starting from the project root dir
+    for dirpath, _, _ in os.walk(os.getcwd()):
+        cred_file = os.path.join(dirpath, "login.inf")
+        if os.path.isfile(cred_file):
+            [args.username, args.password] = [line.strip() for line in open(cred_file, 'r')]
+            break
+
     try:
         args.function(args)
     except AttributeError:
@@ -62,10 +70,10 @@ def get_folder_data(args):
     Set ad data inf file and extract login credentials from inf files
     """
     args.inf_file = "item.inf"
-    cred_file = args.folder_name + "/login.inf"
-    creds = [line.strip() for line in open(cred_file, 'r')]
-    args.username = creds[0]
-    args.password = creds[1]
+    cred_file = os.path.join(args.folder_name, "login.inf")
+    # If "login.inf" credentials file exists within the ad folder, give preference to it
+    if os.path.isfile(cred_file):
+        [args.username, args.password] = [line.strip() for line in open(cred_file, 'r')]
 
 
 def get_inf_details(inf_file):


### PR DESCRIPTION
Recursively search for a common "login.inf" credentials file starting at the project root directory. If found, use it as login credentials for the current API command. It will still check for the presence of a "login.inf" file within the same directory as the ad folder and if found it will use that credential file instead, overwriting any existing login credentials.

With this change, you can keep a single "login.inf" file somewhere within the project root directory and not have to always specify the "-u" and "-p" arguments and not have the need to keep a duplicate of the same credential file in every ad folder.