### PR TITLE
 Change the way photos and .inf files are loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
-listings/
-*.inf
 /.idea/
+*.yml

--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@
 
 ### Generating a .inf file for an ad
 - Generate a posting file (item.inf) with the command `python kijiji_repost_headless build_ad` and follow the prompts
-- Place all photo dependancies in the current directory
+- Place all photo dependancies in the path RELATIVE to item.kj_post 
+- It is recommended that you create folders for each item that you wish to post, and include item.kj_post and photos in that directory
 
 ### Posting + Reposting an ad
-Make sure you're in the ROOT directory of the project before proceeding!
+To post item.kj_post:
 
-To post item.inf:
+`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.kj_post`
 
-`python kijiji_repost_headless -u (username) -p (password) post item.inf`
+To repost item.kj_post (will delete the ad if it is already posted prior to posting):
 
-To repost item.inf (will delete the ad if it is already posted prior to posting):
-
-`python kijiji_repost_headless -u (username) -p (password) repost item.inf`
+`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.kj_post`
 
 To delete all ads:
 
@@ -34,18 +33,6 @@ To delete all ads:
 To delete one ad:
 
 `python kijiji_repost_headless -u (username) -p (password) delete (adId)`
-
-Alternatively, there are also commands for posting/reposting an ad from a folder, which is especially useful for saving you from re-entering your username/password 
-
-Inside your folder, include ALL photos, an `item.inf` ad file, and a `login.inf` file with the first line containing your Kijiji login email and the second line containing your Kijiji login password.
-
-To post from folder:
-
-`python kijiji_repost_headless folder (folderName)`
-
-To repost from folder:
-
-`python kijiji_repost_headless repost_folder (folderName)`
 
 ## Project Structure
 
@@ -57,7 +44,7 @@ project
 │
 └───kijiji_repost_headless
 │   │   kijiji_api.py -> Interfaces with Kijiji
-│   │   generate_inf_file.py -> Makes item.inf
+│   │   generate_post_file.py -> Makes item.kj_post
 │   │   get_ids -> Used for retreiving kijiji location data
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@
 
 ### Generating a .inf file for an ad
 - Generate a posting file (item.inf) with the command `python kijiji_repost_headless build_ad` and follow the prompts
-- Place all photo dependancies in the path RELATIVE to item.kj_post 
-- It is recommended that you create folders for each item that you wish to post, and include item.kj_post and photos in that directory
+- Place all photo dependancies in the path RELATIVE to item.yml 
+- It is recommended that you create folders for each item that you wish to post, and include item.yml and photos in that directory
 
 ### Posting + Reposting an ad
-To post item.kj_post:
+To post item.yml:
 
-`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.kj_post`
+`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.yml`
 
-To repost item.kj_post (will delete the ad if it is already posted prior to posting):
+To repost item.yml (will delete the ad if it is already posted prior to posting):
 
-`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.kj_post`
+`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.yml`
 
 To delete all ads:
 
@@ -44,7 +44,7 @@ project
 │
 └───kijiji_repost_headless
 │   │   kijiji_api.py -> Interfaces with Kijiji
-│   │   generate_post_file.py -> Makes item.kj_post
+│   │   generate_post_file.py -> Makes item.yml
 │   │   get_ids -> Used for retreiving kijiji location data
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -3,10 +3,10 @@ import os
 import sys
 from time import sleep
 
-import kijiji_api
-import generate_post_file as generator
-
 import yaml
+
+import generate_post_file as generator
+import kijiji_api
 
 if sys.version_info < (3, 0):
     raise Exception("This program requires Python 3.0 or greater")
@@ -21,7 +21,7 @@ def main():
     subparsers = parser.add_subparsers(help='sub-command help')
 
     post_parser = subparsers.add_parser('post', help='post a new ad')
-    post_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    post_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     post_parser.set_defaults(function=post_ad)
 
     show_parser = subparsers.add_parser('show', help='show currently listed ads')
@@ -35,14 +35,14 @@ def main():
     nuke_parser.set_defaults(function=nuke)
 
     check_parser = subparsers.add_parser('check_ad', help='check if ad is active')
-    check_parser.add_argument('folder_name', type=str, help='folder containing ad details')
+    check_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     check_parser.set_defaults(function=check_ad)
 
     repost_parser = subparsers.add_parser('repost', help='repost an existing ad')
-    repost_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    repost_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     repost_parser.set_defaults(function=repost_ad)
 
-    build_parser = subparsers.add_parser('build_ad', help='Generates the item.kj_post file for a new ad')
+    build_parser = subparsers.add_parser('build_ad', help='Generates the item.yml file for a new ad')
     build_parser.set_defaults(function=generate_post_file)
 
     args = parser.parse_args()
@@ -51,40 +51,46 @@ def main():
     except AttributeError:
         parser.print_help()
 
+
 def get_username_if_needed(args, data):
     if args.username is None or args.password is None:
-        args.username = data["username"]
-        args.password = data["password"]
+        args.username = data.pop('username', None)
+        args.password = data.pop('password', None)
 
-def get_post_details(inf_file):
+
+def get_post_details(ad_file):
     """
     Extract ad data from inf file
     """
-    with open(inf_file, 'rt') as infFileLines:
-        #data = {key: val for line in infFileLines for (key, val) in (line.strip().split("="),)}
-        data = yaml.load(infFileLines) 
-        files = [open(os.path.join(os.path.dirname(inf_file), picture), 'rb').read() for picture in data['image_paths']]
+    with open(ad_file, 'r') as f:
+        data = yaml.load(f)
+
+    files = [open(os.path.join(os.path.dirname(ad_file), picture), 'rb').read() for picture in data['image_paths']]
+
+    # Remove image_paths key; it does not need to be sent in the HTTP post request later on
+    del data['image_paths']
+
     return [data, files]
+
 
 def post_ad(args):
     """
     Post new ad
     """
-    [data, image_files] = get_post_details(args.inf_file)
+    [data, image_files] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
-    attempts = 1
-    del data["username"]
-    del data["password"]
 
+    attempts = 1
     while not check_ad(args) and attempts < 5:
         if attempts > 1:
-            print("Failed Attempt #{}, trying again.".format(attempts))
+            print("Failed ad post attempt #{}, trying again.".format(attempts))
         attempts += 1
+
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
         api.post_ad_using_data(data, image_files)
     if not check_ad(args):
-        print("Failed Attempt #{}, giving up.".format(attempts))
+        print("Failed ad post attempt #{}, giving up.".format(attempts))
 
 
 def show_ads(args):
@@ -119,37 +125,41 @@ def repost_ad(args):
 
     Try to delete ad with same title if possible before reposting new ad
     """
-
-    [data, image_files] = get_post_details(args.inf_file)
+    [data, _] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
 
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
     del_ad_name = ""
     for item in data:
-        if item[0] == "postAdForm.title":
-            del_ad_name = item[0]
+        if item == "postAdForm.title":
+            del_ad_name = data[item]
     try:
         api.delete_ad_using_title(del_ad_name)
         print("Existing ad deleted before reposting")
-    except kijiji_api.DeleteAdException:
+    except kijiji_api.KijijiApiException:
         print("Did not find an existing ad with matching title, skipping ad deletion")
         pass
+
     # Must wait a bit before posting the same ad even after deleting it, otherwise Kijiji will automatically remove it
     sleep(180)
     post_ad(args)
+
 
 def check_ad(args):
     """
     Check if ad is live
     """
+    [data, _] = get_post_details(args.ad_file)
+    get_username_if_needed(args, data)
+
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
     ad_name = ""
-    [data, image_files] = get_post_details(args.inf_file)
     for key, val in data.items():
         if key == "postAdForm.title":
             ad_name = val
+            break
 
     all_ads = api.get_all_ads()
     return [t for t, i in all_ads if t == ad_name]

--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -3,6 +3,7 @@
 import json
 from operator import itemgetter
 import os
+import yaml
 
 import requests
 
@@ -130,7 +131,7 @@ def get_description():
 
 def run_program():
     print("****************************************************************")
-    print("* Creating the item.inf file. Please answer all the questions. *")
+    print("* Creating the item.kj_post file. Please answer all the questions. *")
     print("****************************************************************\n")
 
     print("Your ad must be submitted in a specific category.")
@@ -146,35 +147,54 @@ def run_program():
         price = input("Ad price in dollars: ")
     print("Ad type:")
     ad = get_enum(adType)
-    photos = input("List of image filenames to upload (comma separated): ")
+    photos = []
+    photos_len = int(input("Specify how many images are there to upload"))
+    for i in range(photos_len):
+        photos.append(input("Specify the relative path of image relative to the .kj_post file {}".format(i+1)))
 
-    f = open('item.inf', 'w')
-    f.write("postAdForm.geocodeLat={}\n".format(addressMap['lat']))
-    f.write("postAdForm.geocodeLng={}\n".format(addressMap['lng']))
-    f.write("postAdForm.city={}\n".format(addressMap['city']))
-    f.write("postAdForm.addressCity={}\n".format(addressMap['city']))
-    f.write("postAdForm.province={}\n".format(addressMap['province']))
-    f.write("postAdForm.addressProvince={}\n".format(addressMap['province']))
-    f.write("postAdForm.postalCode={}\n".format(addressMap['postal_code']))
-    f.write("postAdForm.addressPostalCode={}\n".format(addressMap['postal_code']))
-    f.write("PostalLat={}\n".format(addressMap['lat']))
-    f.write("PostalLng={}\n".format(addressMap['lng']))
-    f.write("categoryId={}\n".format(categoryMap['category']))
-    f.write("postAdForm.adType={}\n".format(ad))
-    f.write("postAdForm.priceType={}\n".format(pmtType))
+    username = input("Kijiji username")
+    password = input("Kijiji password")
+
+    details = {}
+
+    details['postAdForm.geocodeLat'] = addressMap['lat']
+    details['postAdForm.geocodeLng'] = addressMap['lng']
+    details['PostalLat'] = addressMap['lat']
+    details['PostalLng'] = addressMap['lng']
+    details['postAdForm.city'] = addressMap['city']
+    details['postAdForm.addressCity'] = addressMap['city']
+    details['postAdForm.province'] = addressMap['province']
+    details['postAdForm.addressProvince'] = addressMap['province']
+    details['postAdForm.postalCode'] = addressMap['postal_code']
+    details['postAdForm.addressPostalCode'] = addressMap['postal_code']
+    details['categoryId'] = categoryMap['category']
+    details['postAdForm.adType'] = ad
+    details['postAdForm.priceType'] = pmtType
     if pmtType == 'FIXED':
-        f.write("postAdForm.priceAmount={}\n".format(price))
-    [f.write("postAdForm.attributeMap[{}]={}\n".format(attrKey, attrVal)) for attrKey, attrVal in categoryMap.items() if attrKey != "category"]
-    f.write("postAdForm.title={}\n".format(title))
-    f.write("postAdForm.description={}\n".format(description))
-    f.write("postAdForm.locationId={}\n".format(locationId))
-    f.write("locationLevel0={}\n".format(locationArea))
-    f.write("featuresForm.topAdDuration=7\n")
-    f.write("submitType=saveAndCheckout\n")
-    f.write("imageCsv={}\n".format(photos))
+        details["postAdForm.priceAmount"] = price
+    for attrKey, attrVal in categoryMap.items():
+        if attrKey != "category":
+            details["postAdForm.attributeMap[{}]".format(attrKey)] = attrVal
+
+    details["postAdForm.title"]=title
+    details["postAdForm.description"]=description
+    details["postAdForm.locationId"]=locationId
+    details["locationLevel0"]=locationArea
+    details["topAdDuration"]="7"
+    details["submitType"]="saveAndCheckout"
+    details["image_paths"]=photos
+
+    details["username"]=username
+    details["password"]=password
+
+    f = open("item.kj_post", "w")
+    f.write(yaml.dump(details))
     f.close()
 
-    print("item.inf file created. Use this file to post your ad.")
+
+
+
+    print("item.kj_post file created. Use this file to post your ad.")
 
 
 if __name__ == '__main__':

--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -131,7 +131,7 @@ def get_description():
 
 def run_program():
     print("****************************************************************")
-    print("* Creating the item.kj_post file. Please answer all the questions. *")
+    print("* Creating the item.yml file. Please answer all the questions. *")
     print("****************************************************************\n")
 
     print("Your ad must be submitted in a specific category.")
@@ -148,12 +148,12 @@ def run_program():
     print("Ad type:")
     ad = get_enum(adType)
     photos = []
-    photos_len = int(input("Specify how many images are there to upload"))
+    photos_len = int(input("Specify how many images are there to upload: "))
     for i in range(photos_len):
-        photos.append(input("Specify the relative path of image relative to the .kj_post file {}".format(i+1)))
+        photos.append(input("Specify the path of image #{} relative to the .yml file: ".format(i+1)))
 
-    username = input("Kijiji username")
-    password = input("Kijiji password")
+    username = input("Kijiji username: ")
+    password = input("Kijiji password: ")
 
     details = {}
 
@@ -187,14 +187,11 @@ def run_program():
     details["username"]=username
     details["password"]=password
 
-    f = open("item.kj_post", "w")
+    f = open("item.yml", "w")
     f.write(yaml.dump(details))
     f.close()
 
-
-
-
-    print("item.kj_post file created. Use this file to post your ad.")
+    print("\"item.yml\" file created. Use this file to post your ad.")
 
 
 if __name__ == '__main__':

--- a/kijiji_repost_headless/inf2yaml.py
+++ b/kijiji_repost_headless/inf2yaml.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+
+import yaml
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert old inf ad format to new yaml ad format. "
+                                                 "Please double check converted yaml file after! "
+                                                 "Conversion not guaranteed to be 100% accurate.")
+    parser.add_argument('inf_file', nargs='?', default="item.inf", help="Old inf file to convert")
+    parser.add_argument('yml_file', nargs='?', default="item.yml", help="New yaml file to create")
+    args = parser.parse_args()
+
+    with open(args.inf_file, 'r') as f:
+        d = {key: val for line in f for (key, val) in (line.strip().split("="),)}
+
+    # Add new dict keys as copies of existing keys
+    d['postAdForm.addressCity'] = d['postAdForm.city']
+    d['postAdForm.addressProvince'] = d['postAdForm.province']
+    d['postAdForm.addressPostalCode'] = d['postAdForm.postalCode']
+
+    # Rename some dict keys to their new values
+    d['topAdDuration'] = d.pop('featuresForm.topAdDuration')
+
+    # Convert csv to list
+    d['image_paths'] = [i for i in d.pop('imageCsv').split(',')]
+
+    with open(args.yml_file, 'w+') as f:
+        f.write(yaml.dump(d))
+
+    print("\"{}\" inf file converted to \"{}\" yaml file.".format(os.path.basename(args.inf_file), os.path.basename(args.yml_file)))

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -150,11 +150,11 @@ class KijijiApi:
                 try:
                     image_tree = json.loads(r.text)
                     img_url = image_tree['thumbnailUrl']
-                    print("Image Upload success on try #{}".format(i+1))
+                    print("Image upload success on try #{}".format(i+1))
                     image_urls.append(img_url)
                     break
                 except (KeyError, ValueError):
-                    print("Image Upload failed on try #{}".format(i+1))
+                    print("Image upload failed on try #{}".format(i+1))
         return [image for image in image_urls if image is not None]
 
     def post_ad_using_data(self, data, image_files=[]):


### PR DESCRIPTION
- .inf files are now called .kj_post (to minimize confusion with backward compatibility)
- .kj_post files now use YAML, all past .inf files are now incompatible
- Allow storing login info in kj_post files
- Images are stored relative to the .kj_post location, to minimize confusion for new users
- Remove repost_folder and folder commands, since kj_post files make them useless
- Minor code cleanup