### PR TITLE
Workaround for "userid not found" exception

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -37,7 +37,8 @@ def get_token(html, attrib_name):
     soup = bs4.BeautifulSoup(html, 'html.parser')
     res = soup.select("[name={}]".format(attrib_name))
     if not res:
-        raise KijijiApiException("Element with name attribute '{}' not found in html text.".format(attrib_name), html)
+        print("Element with name attribute '{}' not found in html text.".format(attrib_name))
+        return ""
     return res[0]['value']
 
 


### PR DESCRIPTION
The userid token isn't needed for the get-my-ads url, the page gives a proper response if you send nothing.