### PR TITLE
Improvements to new-file-format2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
-listings/
-*.inf
 /.idea/
+*.kj_post

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
 /.idea/
-*.kj_post
+*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
 /.idea/
-*.yaml
+*.yml

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@
 
 ### Generating a .inf file for an ad
 - Generate a posting file (item.inf) with the command `python kijiji_repost_headless build_ad` and follow the prompts
-- Place all photo dependancies in the path RELATIVE to item.kj_post 
-- It is recommended that you create folders for each item that you wish to post, and include item.kj_post and photos in that directory
+- Place all photo dependancies in the path RELATIVE to item.yaml 
+- It is recommended that you create folders for each item that you wish to post, and include item.yaml and photos in that directory
 
 ### Posting + Reposting an ad
-To post item.kj_post:
+To post item.yaml:
 
-`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.kj_post`
+`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.yaml`
 
-To repost item.kj_post (will delete the ad if it is already posted prior to posting):
+To repost item.yaml (will delete the ad if it is already posted prior to posting):
 
-`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.kj_post`
+`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.yaml`
 
 To delete all ads:
 
@@ -44,7 +44,7 @@ project
 │
 └───kijiji_repost_headless
 │   │   kijiji_api.py -> Interfaces with Kijiji
-│   │   generate_post_file.py -> Makes item.kj_post
+│   │   generate_post_file.py -> Makes item.yaml
 │   │   get_ids -> Used for retreiving kijiji location data
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@
 
 ### Generating a .inf file for an ad
 - Generate a posting file (item.inf) with the command `python kijiji_repost_headless build_ad` and follow the prompts
-- Place all photo dependancies in the path RELATIVE to item.yaml 
-- It is recommended that you create folders for each item that you wish to post, and include item.yaml and photos in that directory
+- Place all photo dependancies in the path RELATIVE to item.yml 
+- It is recommended that you create folders for each item that you wish to post, and include item.yml and photos in that directory
 
 ### Posting + Reposting an ad
-To post item.yaml:
+To post item.yml:
 
-`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.yaml`
+`python kijiji_repost_headless -u (username) -p (password) post myproduct/item.yml`
 
-To repost item.yaml (will delete the ad if it is already posted prior to posting):
+To repost item.yml (will delete the ad if it is already posted prior to posting):
 
-`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.yaml`
+`python kijiji_repost_headless -u (username) -p (password) repost myproduct/item.yml`
 
 To delete all ads:
 
@@ -44,7 +44,7 @@ project
 │
 └───kijiji_repost_headless
 │   │   kijiji_api.py -> Interfaces with Kijiji
-│   │   generate_post_file.py -> Makes item.yaml
+│   │   generate_post_file.py -> Makes item.yml
 │   │   get_ids -> Used for retreiving kijiji location data
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has
 │   │   kijiji_categories_attr.json -> Finds out what properties each item has

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -128,8 +128,8 @@ def repost_ad(args):
     api.login(args.username, args.password)
     del_ad_name = ""
     for item in data:
-        if item[0] == "postAdForm.title":
-            del_ad_name = item[0]
+        if item == "postAdForm.title":
+            del_ad_name = data[item]
     try:
         api.delete_ad_using_title(del_ad_name)
         print("Existing ad deleted before reposting")

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -54,8 +54,8 @@ def main():
 
 def get_username_if_needed(args, data):
     if args.username is None or args.password is None:
-        args.username = data.pop("username", None)
-        args.password = data.pop("password", None)
+        args.username = data.pop('username', None)
+        args.password = data.pop('password', None)
 
 
 def get_post_details(ad_file):
@@ -64,7 +64,12 @@ def get_post_details(ad_file):
     """
     with open(ad_file, 'r') as f:
         data = yaml.load(f)
-        files = [open(os.path.join(os.path.dirname(ad_file), picture), 'rb').read() for picture in data['image_paths']]
+
+    files = [open(os.path.join(os.path.dirname(ad_file), picture), 'rb').read() for picture in data['image_paths']]
+
+    # Remove image_paths key; it does not need to be sent in the HTTP post request later on
+    del data['image_paths']
+
     return [data, files]
 
 
@@ -78,14 +83,14 @@ def post_ad(args):
     attempts = 1
     while not check_ad(args) and attempts < 5:
         if attempts > 1:
-            print("Failed Attempt #{}, trying again.".format(attempts))
+            print("Failed ad post attempt #{}, trying again.".format(attempts))
         attempts += 1
 
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
         api.post_ad_using_data(data, image_files)
     if not check_ad(args):
-        print("Failed Attempt #{}, giving up.".format(attempts))
+        print("Failed ad post attempt #{}, giving up.".format(attempts))
 
 
 def show_ads(args):
@@ -154,6 +159,7 @@ def check_ad(args):
     for key, val in data.items():
         if key == "postAdForm.title":
             ad_name = val
+            break
 
     all_ads = api.get_all_ads()
     return [t for t, i in all_ads if t == ad_name]

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -3,10 +3,9 @@ import os
 import sys
 from time import sleep
 
+import yaml
 import kijiji_api
 import generate_post_file as generator
-
-import yaml
 
 if sys.version_info < (3, 0):
     raise Exception("This program requires Python 3.0 or greater")
@@ -21,7 +20,7 @@ def main():
     subparsers = parser.add_subparsers(help='sub-command help')
 
     post_parser = subparsers.add_parser('post', help='post a new ad')
-    post_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    post_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
     post_parser.set_defaults(function=post_ad)
 
     show_parser = subparsers.add_parser('show', help='show currently listed ads')
@@ -35,14 +34,14 @@ def main():
     nuke_parser.set_defaults(function=nuke)
 
     check_parser = subparsers.add_parser('check_ad', help='check if ad is active')
-    check_parser.add_argument('folder_name', type=str, help='folder containing ad details')
+    check_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
     check_parser.set_defaults(function=check_ad)
 
     repost_parser = subparsers.add_parser('repost', help='repost an existing ad')
-    repost_parser.add_argument('inf_file', type=str, help='.inf file containing posting details')
+    repost_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
     repost_parser.set_defaults(function=repost_ad)
 
-    build_parser = subparsers.add_parser('build_ad', help='Generates the item.kj_post file for a new ad')
+    build_parser = subparsers.add_parser('build_ad', help='Generates the item.yaml file for a new ad')
     build_parser.set_defaults(function=generate_post_file)
 
     args = parser.parse_args()
@@ -60,9 +59,8 @@ def get_post_details(inf_file):
     """
     Extract ad data from inf file
     """
-    with open(inf_file, 'rt') as infFileLines:
-        #data = {key: val for line in infFileLines for (key, val) in (line.strip().split("="),)}
-        data = yaml.load(infFileLines) 
+    with open(inf_file, 'rt') as f:
+        data = yaml.load(f)
         files = [open(os.path.join(os.path.dirname(inf_file), picture), 'rb').read() for picture in data['image_paths']]
     return [data, files]
 

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -21,7 +21,7 @@ def main():
     subparsers = parser.add_subparsers(help='sub-command help')
 
     post_parser = subparsers.add_parser('post', help='post a new ad')
-    post_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
+    post_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     post_parser.set_defaults(function=post_ad)
 
     show_parser = subparsers.add_parser('show', help='show currently listed ads')
@@ -35,14 +35,14 @@ def main():
     nuke_parser.set_defaults(function=nuke)
 
     check_parser = subparsers.add_parser('check_ad', help='check if ad is active')
-    check_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
+    check_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     check_parser.set_defaults(function=check_ad)
 
     repost_parser = subparsers.add_parser('repost', help='repost an existing ad')
-    repost_parser.add_argument('inf_file', type=str, help='.yaml file containing ad details')
+    repost_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     repost_parser.set_defaults(function=repost_ad)
 
-    build_parser = subparsers.add_parser('build_ad', help='Generates the item.yaml file for a new ad')
+    build_parser = subparsers.add_parser('build_ad', help='Generates the item.yml file for a new ad')
     build_parser.set_defaults(function=generate_post_file)
 
     args = parser.parse_args()
@@ -57,13 +57,14 @@ def get_username_if_needed(args, data):
         args.username = data["username"]
         args.password = data["password"]
 
-def get_post_details(inf_file):
+
+def get_post_details(ad_file):
     """
     Extract ad data from inf file
     """
-    with open(inf_file, 'r') as f:
+    with open(ad_file, 'r') as f:
         data = yaml.load(f)
-        files = [open(os.path.join(os.path.dirname(inf_file), picture), 'rb').read() for picture in data['image_paths']]
+        files = [open(os.path.join(os.path.dirname(ad_file), picture), 'rb').read() for picture in data['image_paths']]
     return [data, files]
 
 
@@ -71,7 +72,7 @@ def post_ad(args):
     """
     Post new ad
     """
-    [data, image_files] = get_post_details(args.inf_file)
+    [data, image_files] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
     attempts = 1
     del data["username"]
@@ -121,7 +122,7 @@ def repost_ad(args):
 
     Try to delete ad with same title if possible before reposting new ad
     """
-    [data, _] = get_post_details(args.inf_file)
+    [data, _] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
 
     api = kijiji_api.KijijiApi()
@@ -146,7 +147,7 @@ def check_ad(args):
     """
     Check if ad is live
     """
-    [data, _] = get_post_details(args.inf_file)
+    [data, _] = get_post_details(args.ad_file)
 
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)

--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -54,8 +54,8 @@ def main():
 
 def get_username_if_needed(args, data):
     if args.username is None or args.password is None:
-        args.username = data["username"]
-        args.password = data["password"]
+        args.username = data.pop("username", None)
+        args.password = data.pop("password", None)
 
 
 def get_post_details(ad_file):
@@ -74,10 +74,8 @@ def post_ad(args):
     """
     [data, image_files] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
-    attempts = 1
-    del data["username"]
-    del data["password"]
 
+    attempts = 1
     while not check_ad(args) and attempts < 5:
         if attempts > 1:
             print("Failed Attempt #{}, trying again.".format(attempts))
@@ -148,6 +146,7 @@ def check_ad(args):
     Check if ad is live
     """
     [data, _] = get_post_details(args.ad_file)
+    get_username_if_needed(args, data)
 
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)

--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -148,12 +148,12 @@ def run_program():
     print("Ad type:")
     ad = get_enum(adType)
     photos = []
-    photos_len = int(input("Specify how many images are there to upload"))
+    photos_len = int(input("Specify how many images are there to upload: "))
     for i in range(photos_len):
-        photos.append(input("Specify the relative path of image relative to the .kj_post file {}".format(i+1)))
+        photos.append(input("Specify the path of image #{} relative to the .kj_post file: ".format(i+1)))
 
-    username = input("Kijiji username")
-    password = input("Kijiji password")
+    username = input("Kijiji username: ")
+    password = input("Kijiji password: ")
 
     details = {}
 
@@ -191,10 +191,7 @@ def run_program():
     f.write(yaml.dump(details))
     f.close()
 
-
-
-
-    print("item.kj_post file created. Use this file to post your ad.")
+    print("\"item.kj_post\" file created. Use this file to post your ad.")
 
 
 if __name__ == '__main__':

--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -130,9 +130,9 @@ def get_description():
 
 
 def run_program():
-    print("*****************************************************************")
-    print("* Creating the item.yaml file. Please answer all the questions. *")
-    print("*****************************************************************\n")
+    print("****************************************************************")
+    print("* Creating the item.yml file. Please answer all the questions. *")
+    print("****************************************************************\n")
 
     print("Your ad must be submitted in a specific category.")
 
@@ -150,7 +150,7 @@ def run_program():
     photos = []
     photos_len = int(input("Specify how many images are there to upload: "))
     for i in range(photos_len):
-        photos.append(input("Specify the path of image #{} relative to the .yaml file: ".format(i+1)))
+        photos.append(input("Specify the path of image #{} relative to the .yml file: ".format(i+1)))
 
     username = input("Kijiji username: ")
     password = input("Kijiji password: ")
@@ -187,11 +187,11 @@ def run_program():
     details["username"]=username
     details["password"]=password
 
-    f = open("item.yaml", "w")
+    f = open("item.yml", "w")
     f.write(yaml.dump(details))
     f.close()
 
-    print("\"item.yaml\" file created. Use this file to post your ad.")
+    print("\"item.yml\" file created. Use this file to post your ad.")
 
 
 if __name__ == '__main__':

--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -130,9 +130,9 @@ def get_description():
 
 
 def run_program():
-    print("****************************************************************")
-    print("* Creating the item.kj_post file. Please answer all the questions. *")
-    print("****************************************************************\n")
+    print("*****************************************************************")
+    print("* Creating the item.yaml file. Please answer all the questions. *")
+    print("*****************************************************************\n")
 
     print("Your ad must be submitted in a specific category.")
 
@@ -150,7 +150,7 @@ def run_program():
     photos = []
     photos_len = int(input("Specify how many images are there to upload: "))
     for i in range(photos_len):
-        photos.append(input("Specify the path of image #{} relative to the .kj_post file: ".format(i+1)))
+        photos.append(input("Specify the path of image #{} relative to the .yaml file: ".format(i+1)))
 
     username = input("Kijiji username: ")
     password = input("Kijiji password: ")
@@ -187,11 +187,11 @@ def run_program():
     details["username"]=username
     details["password"]=password
 
-    f = open("item.kj_post", "w")
+    f = open("item.yaml", "w")
     f.write(yaml.dump(details))
     f.close()
 
-    print("\"item.kj_post\" file created. Use this file to post your ad.")
+    print("\"item.yaml\" file created. Use this file to post your ad.")
 
 
 if __name__ == '__main__':

--- a/kijiji_repost_headless/inf2yaml.py
+++ b/kijiji_repost_headless/inf2yaml.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
                                                  "Please double check converted yaml file after! "
                                                  "Conversion not guaranteed to be 100% accurate.")
     parser.add_argument('inf_file', nargs='?', default="item.inf", help="Old inf file to convert")
-    parser.add_argument('yaml_file', nargs='?', default="item.yaml", help="New yaml file to create")
+    parser.add_argument('yml_file', nargs='?', default="item.yml", help="New yaml file to create")
     args = parser.parse_args()
 
     with open(args.inf_file, 'r') as f:
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     # Convert csv to list
     d['image_paths'] = [i for i in d.pop('imageCsv').split(',')]
 
-    with open(args.yaml_file, 'w+') as f:
+    with open(args.yml_file, 'w+') as f:
         f.write(yaml.dump(d))
 
-    print("\"{}\" inf file converted to \"{}\" yaml file.".format(os.path.basename(args.inf_file), os.path.basename(args.yaml_file)))
+    print("\"{}\" inf file converted to \"{}\" yaml file.".format(os.path.basename(args.inf_file), os.path.basename(args.yml_file)))

--- a/kijiji_repost_headless/inf2yaml.py
+++ b/kijiji_repost_headless/inf2yaml.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+
+import yaml
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert old inf ad format to new yaml ad format. "
+                                                 "Please double check converted yaml file after! "
+                                                 "Conversion not guaranteed to be 100% accurate.")
+    parser.add_argument('inf_file', nargs='?', default="item.inf", help="Old inf file to convert")
+    parser.add_argument('yaml_file', nargs='?', default="item.yaml", help="New yaml file to create")
+    args = parser.parse_args()
+
+    with open(args.inf_file, 'r') as f:
+        d = {key: val for line in f for (key, val) in (line.strip().split("="),)}
+
+    # Add new dict keys as copies of existing keys
+    d['postAdForm.addressCity'] = d['postAdForm.city']
+    d['postAdForm.addressProvince'] = d['postAdForm.province']
+    d['postAdForm.addressPostalCode'] = d['postAdForm.postalCode']
+
+    # Rename some dict keys to their new values
+    d['topAdDuration'] = d.pop('featuresForm.topAdDuration')
+
+    # Convert csv to list
+    d['image_paths'] = [i for i in d.pop('imageCsv').split(',')]
+
+    with open(args.yaml_file, 'w+') as f:
+        f.write(yaml.dump(d))
+
+    print("\"{}\" inf file converted to \"{}\" yaml file.".format(os.path.basename(args.inf_file), os.path.basename(args.yaml_file)))

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -150,11 +150,11 @@ class KijijiApi:
                 try:
                     image_tree = json.loads(r.text)
                     img_url = image_tree['thumbnailUrl']
-                    print("Image Upload success on try #{}".format(i+1))
+                    print("Image upload success on try #{}".format(i+1))
                     image_urls.append(img_url)
                     break
                 except (KeyError, ValueError):
-                    print("Image Upload failed on try #{}".format(i+1))
+                    print("Image upload failed on try #{}".format(i+1))
         return [image for image in image_urls if image is not None]
 
     def post_ad_using_data(self, data, image_files=[]):


### PR DESCRIPTION
- .kj_post file extension changed to .yml to better reflect what the file format is
  - We don't need to be creating out own custom file extensions
  - When opening these files in syntax-aware editors, they can correctly know the formatting syntax
- Fixed up all references to ".inf" so that they now reference ".yml"
- Fix bug in finding existing ad titles to delete before reposting
- Added helper script `inf2yaml.py` to convert old inf ad format to new yaml ad format
- Minor syntax whitespace changes

Note that this branch does _not_ contain the recent fix for getting active ad IDs (274018268f1599cc8318fe99b5276081cee1a979) however once merged into the master branch it will have this fix.