### PR TITLE
Support getting active ad ranks (page numbers)

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -99,7 +99,14 @@ def show_ads(args):
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    [print("{} '{}'".format(ad_id, ad_name)) for ad_name, ad_id in api.get_all_ads()]
+    all_ads = api.get_all_ads()
+    print("    id    ", "page", "views", "          title")
+    [print("{ad_id:10} {rank:4} {views:5} '{title}'".format(
+        ad_id=ad['id'],
+        rank=ad['rank'],
+        views=ad['views'],
+        title=ad['title']
+    )) for ad in all_ads]
 
 
 def delete_ad(args):
@@ -156,24 +163,24 @@ def check_ad(args):
 
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
-    ad_name = ""
+    ad_title = ""
     for key, val in data.items():
         if key == "postAdForm.title":
-            ad_name = val
+            ad_title = val
             break
 
     all_ads = api.get_all_ads()
-    return [t for t, i in all_ads if t == ad_name]
+    return [ad['title'] for ad in all_ads if ad['title'] == ad_title]
 
 
 def nuke(args):
     """
-    Delete all ads
+    Delete all active ads
     """
     api = kijiji_api.KijijiApi()
     api.login(args.username, args.password)
     all_ads = api.get_all_ads()
-    [api.delete_ad(ad_id) for ad_name, ad_id in all_ads]
+    [api.delete_ad(ad['id']) for ad in all_ads]
 
 
 def generate_post_file(args):

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -215,11 +215,10 @@ class KijijiApi:
         ads_info = ads_json['ads']
 
         # Get rank (ie. page number) for each ad
-        # Construct url in the form of "https://www.kijiji.ca/my/ranks?ids=<ad_id1>&ids=<ad_id2>&..."
-        # where each ad ID given returns its page rank
-        query_str = "&".join("ids={}".format(ad_id) for ad_id in [ad['id'] for ad in ads_info.values()])
-        ad_rank_url = "https://www.kijiji.ca/my/ranks?{}".format(query_str)
-        resp = self.session.get(ad_rank_url)
+        # Can't use dict comprehension for building params because every key has the same name,
+        # must use a list of key-value tuples instead
+        params = [("ids", ad['id']) for ad in ads_info.values()]
+        resp = self.session.get('https://www.kijiji.ca/my/ranks', params=params)
         resp.raise_for_status()
         ranks_json = json.loads(resp.text)
 


### PR DESCRIPTION
get_all_ads() now returns a list of dicts for each active ad containing more ad properties
Updated 'show' subcommand to print each ad's current page and number of views