### PR TITLE
Only get ad ranks when there are active ads

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -214,16 +214,17 @@ class KijijiApi:
         ads_json = json.loads(resp.text)
         ads_info = ads_json['ads']
 
-        # Get rank (ie. page number) for each ad
-        # Can't use dict comprehension for building params because every key has the same name,
-        # must use a list of key-value tuples instead
-        params = [("ids", ad['id']) for ad in ads_info.values()]
-        resp = self.session.get('https://www.kijiji.ca/my/ranks', params=params)
-        resp.raise_for_status()
-        ranks_json = json.loads(resp.text)
+        if ads_info:
+            # Get rank (ie. page number) for each ad
+            # Can't use dict comprehension for building params because every key has the same name,
+            # must use a list of key-value tuples instead
+            params = [("ids", ad['id']) for ad in ads_info.values()]
+            resp = self.session.get('https://www.kijiji.ca/my/ranks', params=params)
+            resp.raise_for_status()
+            ranks_json = json.loads(resp.text)
 
-        # Add ranks to existing ad properties dict
-        for ad_id, rank in ranks_json['ranks'].items():
-            ads_info[ad_id]['rank'] = rank
+            # Add ranks to existing ad properties dict
+            for ad_id, rank in ranks_json['ranks'].items():
+                ads_info[ad_id]['rank'] = rank
 
         return [ad for ad in ads_info.values()]


### PR DESCRIPTION
When there are no prior active ads, get_all_ads() will still try to get ad rankings (ie. page numbers) for each ad but this fails because there are no ads to check in the first place.

Specifically, it does an HTTP GET for "https://www.kijiji.ca/my/ranks" (no params) which returns an HTTP 500 error.