### PR TITLE
Optional argument to show ad list in sorted order by a given key

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -26,6 +26,8 @@ def main():
 
     show_parser = subparsers.add_parser('show', help='show currently listed ads')
     show_parser.set_defaults(function=show_ads)
+    show_parser.add_argument('-k', '--key', dest='sort_key', help="sort list by key: 'id', 'title', 'page', or 'views'")
+    show_parser.add_argument('-r', '--reverse', action='store_true', dest='sort_reverse', help='reverse sort order')
 
     delete_parser = subparsers.add_parser('delete', help='delete a listed ad')
     delete_parser.add_argument('id', type=str, help='id of the ad you wish to delete')
@@ -42,10 +44,15 @@ def main():
     repost_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     repost_parser.set_defaults(function=repost_ad)
 
-    build_parser = subparsers.add_parser('build_ad', help='Generates the item.yml file for a new ad')
+    build_parser = subparsers.add_parser('build_ad', help='generates the item.yml file for a new ad')
     build_parser.set_defaults(function=generate_post_file)
 
     args = parser.parse_args()
+
+    # Sort reverse argument is mutually inclusive with sort key argument
+    if args.sort_reverse and args.sort_key is None:
+        parser.error("sort reverse argument (-r, --reverse) requires a sort key argument (-k, --key)")
+
     try:
         args.function(args)
     except AttributeError:
@@ -102,6 +109,23 @@ def show_ads(args, api=None):
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
     all_ads = api.get_all_ads()
+
+    # Sort list of ads if a sort key was given
+    if args.sort_key:
+        key = args.sort_key
+        if key.lower() == 'id':
+            sort_key = 'id'
+        elif key.lower() == 'title' or key.lower() == 'name':
+            sort_key = 'title'
+        elif key.lower().startswith('rank') or key.lower().startswith('page'):
+            sort_key = 'rank'
+        elif key.lower().startswith('view'):
+            sort_key = 'views'
+        else:
+            print("Sort key '{}' is not valid!".format(key))
+            return
+        all_ads = sorted(all_ads, key=lambda k: k[sort_key], reverse=args.sort_reverse)
+
     print("    id    ", "page", "views", "          title")
     [print("{ad_id:10} {rank:4} {views:5} '{title}'".format(
         ad_id=ad['id'],


### PR DESCRIPTION
New additional arguments for the `show` subcommand to sort the output list based on a given key (ie. column). Also supports sorting in reverse order.

Examples:

Sort by ad title in ascending order
`python3 kijiji_repost_headless -u kijijiuser@example.com -p secretpassw0rd show -k title`

Sort by number of ad views in descending (reverse) order
`python3 kijiji_repost_headless -u kijijiuser@example.com -p secretpassw0rd show -k views -r`