### PR TITLE
Force utf-8 encoding when writing dump file

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -19,8 +19,8 @@ class KijijiApiException(Exception):
         self.msg = msg
         self.dumpfilepath = ""
         if dump:
-            self.dumpfilepath = "kijijiapi_dump_{}.txt".format(strftime("%Y%m%dT%H%M%S"))
-            with open(self.dumpfilepath, 'a') as f:
+            self.dumpfilepath = "kijijiapi_dump_{}.html".format(strftime("%Y%m%dT%H%M%S"))
+            with open(self.dumpfilepath, 'a', encoding='utf-8') as f:
                 f.write(dump)
 
     def __str__(self):


### PR DESCRIPTION
* Force using utf-8 encoding when writing dump file
  * Fixes problems where `UnicodeEncodeError` is thrown in cases where the user's local encoding is not set to utf-8 (eg. Windows) and Python tries to write a unicode character
* Change file extension from txt to html