### PR TITLE
Removed leading and trailing characters from ad title.

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -70,6 +70,8 @@ def get_post_details(ad_file, api=None):
 
     # Remove image_paths key; it does not need to be sent in the HTTP post request later on
     del data['image_paths']
+    
+    data['postAdForm.title'] = data['postAdForm.title'].strip()
 
     return [data, files]
 


### PR DESCRIPTION
Leading and trailing characters in the ad title caused a bug while uploading images. Applied strip() to the 'postAdForm.title' key before using the data in other functions.