### PR TITLE
Fix css attribute selector syntax to match css specification

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -35,7 +35,7 @@ def get_token(html, attrib_name):
     Return value of first match for element with name attribute
     """
     soup = bs4.BeautifulSoup(html, 'html.parser')
-    res = soup.select("[name={}]".format(attrib_name))
+    res = soup.select("[name='{}']".format(attrib_name))
     if not res:
         raise KijijiApiException("Element with name attribute '{}' not found in html text.".format(attrib_name), html)
     return res[0]['value']


### PR DESCRIPTION
Fixes #128 and #131 

See [comment in issue 128](https://github.com/ArthurG/Kijiji-Repost-Headless/issues/128#issuecomment-452728738) for explanation.