### PR TITLE
fix #139 - define loader for the load function

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -64,13 +64,13 @@ def get_post_details(ad_file, api=None):
     Extract ad data from inf file
     """
     with open(ad_file, 'r') as f:
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.FullLoader)
 
     files = [open(os.path.join(os.path.dirname(ad_file), picture), 'rb').read() for picture in data['image_paths']]
 
     # Remove image_paths key; it does not need to be sent in the HTTP post request later on
     del data['image_paths']
-    
+
     data['postAdForm.title'] = data['postAdForm.title'].strip()
 
     return [data, files]

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -70,7 +70,7 @@ def get_xsrf_token(html):
             m = p.search(script.string.replace("\n", ""))
             if m:
                 # Using yaml to load since this is not valid JSON
-                return yaml.load(m.group(1))['token']
+                return yaml.load(m.group(1), Loader=yaml.FullLoader)['token']
     raise KijijiApiException("XSRF token not found in html text.", html)
 
 
@@ -97,7 +97,7 @@ class KijijiApi:
             'targetUrl': get_kj_data(resp.text)['config']['targetUrl'],
         }
         resp = self.session.post(login_url, data=payload)
-	
+
         if not self.is_logged_in():
             raise KijijiApiException("Could not log in.", resp.text)
 


### PR DESCRIPTION
This page explains the PyYAML 5.1 deprecation of the plain yaml.load(input) function. 
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation