### PR TITLE
Delete CMD option uses YAML file instead of Ad ID

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -29,7 +29,7 @@ def main():
     show_parser.add_argument('-r', '--reverse', action='store_true', dest='sort_reverse', help='reverse sort order')
 
     delete_parser = subparsers.add_parser('delete', help='delete a listed ad')
-    delete_parser.add_argument('id', type=str, help='id of the ad you wish to delete')
+    delete_parser.add_argument('ad_file', type=str, help='.yml file containing ad details')
     delete_parser.set_defaults(function=delete_ad)
 
     nuke_parser = subparsers.add_parser('nuke', help='delete all ads')
@@ -119,18 +119,6 @@ def delete_ad(args, api=None):
     """
     Delete ad
     """
-    if not api:
-        api = kijiji_api.KijijiApi()
-        api.login(args.username, args.password)
-    api.delete_ad(args.id)
-
-
-def repost_ad(args, api=None):
-    """
-    Repost ad
-
-    Try to delete ad with same title if possible before reposting new ad
-    """
     [data, _] = get_post_details(args.ad_file)
     get_username_if_needed(args, data)
 
@@ -138,16 +126,24 @@ def repost_ad(args, api=None):
         api = kijiji_api.KijijiApi()
         api.login(args.username, args.password)
 
-    del_ad_name = ""
-    for item in data:
-        if item == "postAdForm.title":
-            del_ad_name = data[item]
-    try:
-        api.delete_ad_using_title(del_ad_name)
-        print("Existing ad deleted before reposting")
-    except kijiji_api.KijijiApiException:
-        print("Did not find an existing ad with matching title, skipping ad deletion")
-        pass
+    if args.ad_file:
+        del_ad_name = ""
+        for item in data:
+            if item == "postAdForm.title":
+                del_ad_name = data[item]
+        try:
+            api.delete_ad_using_title(del_ad_name)
+            print("Deletion successful")
+        except kijiji_api.KijijiApiException:
+            print("Did not find an existing ad with matching title, skipping ad deletion")
+
+def repost_ad(args, api=None):
+    """
+    Repost ad
+
+    Try to delete ad with same title if possible before reposting new ad
+    """
+    delete_ad(args, api)
 
     # Must wait a bit before posting the same ad even after deleting it, otherwise Kijiji will automatically remove it
     print("Waiting 3 minutes before posting again. Please do not exit this script.")


### PR DESCRIPTION
Ad ID is generally very hard to get as a user and it's not intuitive how to obtain. 

So instead we'll allow deleting via YAML file. Hopefully this will be more useful. 