### PR TITLE
Fix "Could not login" error

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -105,9 +105,12 @@ class KijijiApi:
         """
         Return true if logged into Kijiji for the current session
         """
-        txt = self.session.get('https://www.kijiji.ca/m-my-ads.html/').text
-
-        return "Log Out" in txt
+        resp = self.session.get('https://www.kijiji.ca/my/ads.json')
+        try:
+            resp.json()
+            return True
+        except:
+            return False
 
     def logout(self):
         """


### PR DESCRIPTION
Fix #129 by listing the ads the user has
- If the ads listing is successful, the user is probably logged in
- Else, user is not logged in