### PR TITLE
Use town as an replacement for city

### DIFF
--- a/kijiji_repost_headless/generate_post_file.py
+++ b/kijiji_repost_headless/generate_post_file.py
@@ -67,9 +67,11 @@ def get_address_map():
         print()  # Empty line
         return None  # Restart
 
-    try:
+    if "city" in chosen_result['address']:
         city = chosen_result['address']['city'] 
-    except (IndexError, KeyError):
+    elif "town" in chosen_result['address']:
+        city = chosen_result['address']['town'] 
+    else:
         print("Address is too vague; city is missing! Try again.")
         print()  # Empty line
         return None  # Restart


### PR DESCRIPTION
Previously, some locations are represented as "Town" inside
OpenStreetMap rather than "city". This led to error when trying to
determine what city the user is from.

Fixes #165