### PR TITLE
Use new login API endpoint

### DIFF
--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -57,7 +57,7 @@ def get_kj_data(html):
     The 'window.__data' JSON object contains many useful key/values
     """
     soup = bs4.BeautifulSoup(html, 'html.parser')
-    p = re.compile('window.__data=(.*);')
+    p = re.compile(r'window\.__data=(.*);')
     script_list = soup.find_all("script", {"src": False})
     for script in script_list:
         if script:
@@ -74,7 +74,7 @@ def get_xsrf_token(html):
     does not contain the usual 'ca.kijiji.xsrf.token' hidden HTML form input element, which is easier to scrape
     """
     soup = bs4.BeautifulSoup(html, 'html.parser')
-    p = re.compile('Zoop\.init\(.*config: ({.+?}).*\);')
+    p = re.compile(r'Zoop\.init\(.*config: ({.+?}).*\);')
     for script in soup.find_all("script", {"src": False}):
         if script:
             m = p.search(script.string.replace("\n", ""))


### PR DESCRIPTION
Use new Kijiji API endpoint at "_/anvil/api_" for logging in.

Kijiji has once again updated their backend and it appears that they are using a new API endpoint for logging into the site. A POST request must be made to this new endpoint to establish a valid site login. This endpoint expects a JSON object for the request payload with a different set of parameters.

I've confirmed that I am able to list existing ads and repost existing ads with this fix.

Additionally, one minor fix to use raw strings for compiled regex.