### PR TITLE
Make ad delection/checking a bit smarter

### DIFF
--- a/kijiji_repost_headless/__main__.py
+++ b/kijiji_repost_headless/__main__.py
@@ -131,12 +131,15 @@ def delete_ad(args, api=None):
 
     if args.ad_file:
         del_ad_name = ""
+        del_ad_category = -1
         for item in data:
             if item == "postAdForm.title":
                 del_ad_name = data[item]
+            if item == "categoryId":
+                del_ad_category = data[item]
         try:
-            api.delete_ad_using_title(del_ad_name)
-            print("Deletion successful")
+            api.delete_ad_using_title(del_ad_name, del_ad_category)
+            print("Deletion successful or unaffected")
         except kijiji_api.KijijiApiException:
             print("Did not find an existing ad with matching title, skipping ad deletion")
 
@@ -175,13 +178,16 @@ def check_ad(args, api=None):
         api.login(args.username, args.password)
 
     ad_title = ""
+    ad_category = -1
+
     for key, val in data.items():
         if key == "postAdForm.title":
             ad_title = val
-            break
+        if key == "categoryId":
+            ad_category = val
 
     all_ads = api.get_all_ads()
-    return [ad['title'] for ad in all_ads if ad['title'] == ad_title]
+    return [ad['title'] for ad in all_ads if ad['title'] == ad_title and ad['categoryId'] == ad_category]
 
 
 def nuke(args, api=None):

--- a/kijiji_repost_headless/kijiji_api.py
+++ b/kijiji_repost_headless/kijiji_api.py
@@ -152,12 +152,12 @@ class KijijiApi:
         if "OK" not in resp.text:
             raise KijijiApiException("Could not delete ad.", resp.text)
 
-    def delete_ad_using_title(self, title):
+    def delete_ad_using_title(self, title, categoryId):
         """
         Delete ad based on ad title
         """
         all_ads = self.get_all_ads()
-        [self.delete_ad(ad['id']) for ad in all_ads if ad['title'].strip() == title.strip()]
+        [self.delete_ad(ad['id']) for ad in all_ads if ad['title'].strip() == title.strip() and ad['categoryId'] == categoryId]
 
     def upload_image(self, token, image_files=[]):
         """
@@ -167,11 +167,11 @@ class KijijiApi:
         """
         image_urls = []
         image_upload_url = 'https://www.kijiji.ca/p-upload-image.html'
-        for img_file in image_files:
+        for idx, img_file in enumerate(image_files):
             for i in range(0, 3):
                 r = self.session.post(
-                    image_upload_url, 
-                    files={'file': img_file}, 
+                    image_upload_url,
+                    files={'file': img_file},
                     headers={
                         "X-Ebay-Box-Token": token,
                         "User-Agent": session_ua})
@@ -179,11 +179,11 @@ class KijijiApi:
                 try:
                     image_tree = json.loads(r.text)
                     img_url = image_tree['thumbnailUrl']
-                    print("Image upload success on try #{}".format(i+1))
+                    print("Image #{} upload success on try #{}".format(idx + 1, i+1))
                     image_urls.append(img_url)
                     break
                 except (KeyError, ValueError):
-                    print("Image upload failed on try #{}".format(i+1))
+                    print("Image #{} upload failed on try #{}".format(idx + 1, i+1))
         return [image for image in image_urls if image is not None]
 
     def post_ad_using_data(self, data, image_files=[]):


### PR DESCRIPTION
I have multiple ads with the same name under different categories, so everything was being deleted at once. This PR makes it so that when deleting/checking ad existence, it also respects the ads category